### PR TITLE
PCT-369 Alternate create Alias API for DB Connection

### DIFF
--- a/src/java/com/phenix/pct/PCTConnection.java
+++ b/src/java/com/phenix/pct/PCTConnection.java
@@ -204,6 +204,37 @@ public class PCTConnection extends DataType {
             throw new BuildException(MessageFormat.format(
                     Messages.getString("PCTConnection.0"), alias.getName())); //$NON-NLS-1$
     }
+    
+    /**
+     * Adds an alias to the current DB connection.
+     * 
+     * This is here to avoid instantiating PCTAlias
+     * 
+     * @param name Alias name
+     */
+    public void addConfiguredPCTAlias(String name) {
+        addConfiguredPCTAlias(name, false);
+    }    
+    
+    /**
+     * Adds an alias to the current DB connection.
+     * 
+     * This is here to avoid instantiating PCTAlias
+     * 
+     * @param name Alias name
+     * @param noError If alias should be declared with NO-ERROR
+     */
+    public void addConfiguredPCTAlias(String name, boolean noError) {
+        
+        if (name == null || name.isEmpty()) {
+            throw new BuildException(Messages.getString("PCTConnection.2"));
+        }
+        
+        PCTAlias alias = new PCTAlias();
+        alias.setName(name);
+        alias.setNoError(noError);
+        addConfiguredPCTAlias(alias);
+    }    
 
     protected PCTConnection getRef() {
         return (PCTConnection) getCheckedRef();

--- a/src/java/com/phenix/pct/messages.properties
+++ b/src/java/com/phenix/pct/messages.properties
@@ -40,6 +40,8 @@ PCTCompile.91=Ignoring ProgPerc because of a not supported value: {0}
 
 PCTConnection.0=Alias {0} already defined
 PCTConnection.1=Database name or parameter file not defined
+PCTConnection.2=Mandatory argument: alias name
+
 
 PCTCRC.0=Mandatory argument : destination file
 PCTCRC.1=No database connection defined

--- a/src/java/com/phenix/pct/messages_fr.properties
+++ b/src/java/com/phenix/pct/messages_fr.properties
@@ -40,6 +40,7 @@ PCTCompile.91=Invalid value for progPerc : {0}
 
 PCTConnection.0=L'alias {0} est déjà défini
 PCTConnection.1=Le nom de la base ou du fichier de paramètre n'est pas défini
+PCTConnection.2=Argument obligatoire: nom d'alias
 
 PCTCRC.0=Argument obligatoire : fichier cible
 PCTCRC.1=Aucune connexion à une base de données n'a été définie

--- a/src/test/com/phenix/pct/PCTConnectionTest.java
+++ b/src/test/com/phenix/pct/PCTConnectionTest.java
@@ -50,6 +50,38 @@ public class PCTConnectionTest extends BuildFileTestNg {
         PCTConnection conn = new PCTConnection();
         conn.createArguments(exec);
     }
+    
+    // should allow alias by name without instantiating pctalias
+    @Test(groups = {"v10"})
+    public void addConfiguredPCTAlias() {
+        PCTConnection conn = new PCTConnection();
+
+        if (conn.getAliases().size() > 0) {
+            fail("No aliases should be defined at this time");
+        }
+        
+        conn.addConfiguredPCTAlias("boston");
+        
+        assertTrue(conn.hasNamedAlias("boston"));
+        
+        conn.addConfiguredPCTAlias("miami", true);
+        
+        assertTrue(conn.hasNamedAlias("miami"));
+        
+    }
+    
+    // should fail because alias name is blank
+    @Test(groups = {"v10"}, expectedExceptions = BuildException.class)
+    public void addConfiguredPCTAliasErrors() {
+        PCTConnection conn = new PCTConnection();
+
+        if (conn.getAliases().size() > 0) {
+            fail("No aliases should be defined at this time");
+        }
+        
+        conn.addConfiguredPCTAlias("");
+        
+    }    
 
     @Test(groups = {"v10"})
     public void testAliases() {


### PR DESCRIPTION
Need ability to create alias without actually importing PCTAlias into my
groovy class since it isn't available on classpath. Working on gradle
plugin (grabl) and PCTAlias isn't since it is not registered in
types.properties so gradle doesn't load it.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My branch is started from the latest commit in master
- [ ] My commit history is clean
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
